### PR TITLE
Make Encode a supertrait of EncodeLen

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -93,13 +93,13 @@ pub trait FixedEncodeLen {
     const ENCODE_LEN: usize;
 }
 
-impl<T: FixedEncodeLen> FixedEncodeLenHint for T {
+impl<T: FixedEncodeLen + Encode> FixedEncodeLenHint for T {
     const MIN_ENCODE_LEN: usize = Self::ENCODE_LEN;
 
     const MAX_ENCODE_LEN: usize = Self::ENCODE_LEN;
 }
 
-impl<T: FixedEncodeLen> EncodeLen for T {
+impl<T: FixedEncodeLen + Encode> EncodeLen for T {
     #[inline]
     fn encode_len(&self) -> usize {
         Self::ENCODE_LEN

--- a/src/write.rs
+++ b/src/write.rs
@@ -67,7 +67,7 @@ impl<T: Encode + ?Sized> Encode for &T {
 }
 
 /// Gets how many bytes it takes to encode a value of this type.
-pub trait EncodeLen {
+pub trait EncodeLen: Encode {
     /// Gets how many bytes it takes to encode this value into a [`Write`].
     ///
     /// If this function returns `n`, then if you [`Encode::encode`] this value


### PR DESCRIPTION
Currently, `EncodeLen` has the following signature.
```rust
pub trait EncodeLen {
    fn encode_len(&self) -> usize;
}
```

The documentation specifies [here](https://github.com/aecsocket/octs/blob/2ade6135798610b89ac6638cc1115e93804af2f8/src/write.rs#L73-L74) that `EncodeLen::encode_len` is guaranteed to be the amount of bytes written with `Encode::encode`. The problem lies in that you can have a type implement `EncodeLen` but not `Encode`, which makes no sense, because the entire purpose of `EncodeLen` is to be used with `Encode`.

This PR simply adds `Encode` as a supertrait of `EncodeLen`.