### PR TITLE
Expose test mod publicly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "octs"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "bytes",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Finally, a good byte manipulation library"
 name = "octs"
-version = "0.4.1"
+version = "0.4.2"
 
 authors = ["aecsocket <aecsocket@tutanota.com>"]
 categories = ["network-programming", "data-structures"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,50 +14,6 @@ mod write;
 
 pub mod chunks;
 pub mod prim;
+pub mod test;
 
 pub use {error::*, read::*, varint::*, write::*};
-
-#[cfg(test)]
-pub(crate) mod __test {
-    use core::fmt::Debug;
-
-    use bytes::{Buf, BytesMut};
-
-    use crate::{Decode, Encode, EncodeLen, FixedEncodeLenHint, Read, Write};
-
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn round_trip<T>(value: T)
-    where
-        T: Debug + Encode + Decode + EncodeLen + FixedEncodeLenHint + PartialEq,
-        <T as Encode>::Error: Debug,
-        <T as Decode>::Error: Debug,
-    {
-        let encode_len = value.encode_len();
-        assert!(
-            encode_len >= T::MIN_ENCODE_LEN,
-            "encode_len = {encode_len}, T::MIN_ENCODE_LEN: {}",
-            T::MIN_ENCODE_LEN
-        );
-        assert!(
-            encode_len <= T::MAX_ENCODE_LEN,
-            "encode_len = {encode_len}, T::MAX_ENCODE_LEN: {}",
-            T::MAX_ENCODE_LEN
-        );
-
-        let mut buf = BytesMut::with_capacity(encode_len);
-        buf.write(&value).unwrap();
-        assert_eq!(encode_len, buf.len());
-
-        let mut buf = buf.freeze();
-        assert_eq!(encode_len, buf.remaining());
-
-        let buf_clone = buf.clone();
-        let actual = buf.read::<T>().unwrap();
-        assert!(
-            value == actual,
-            "expected = {value:?}, actual = {actual:?}, buf: {:?}",
-            buf_clone.chunk()
-        );
-        assert_eq!(0, buf.remaining());
-    }
-}

--- a/src/prim/bool.rs
+++ b/src/prim/bool.rs
@@ -34,14 +34,16 @@ impl Encode for bool {
 mod tests {
     use super::*;
 
+    use crate::test::*;
+
     #[test]
     fn round_trip_false() {
-        crate::__test::round_trip(false);
+        hint_round_trip(&false);
     }
 
     #[test]
     fn round_trip_true() {
-        crate::__test::round_trip(true);
+        hint_round_trip(&true);
     }
 
     #[test]

--- a/src/prim/nonzero.rs
+++ b/src/prim/nonzero.rs
@@ -110,12 +110,14 @@ mod tests {
 
     use super::*;
 
+    use crate::test::*;
+
     macro_rules! round_trip {
         ($nz:ty, $base:ty) => {
-            crate::__test::round_trip(<$nz>::MIN);
-            crate::__test::round_trip(<$nz>::new(1 as $base).unwrap());
-            crate::__test::round_trip(<$nz>::new(2 as $base).unwrap());
-            crate::__test::round_trip(<$nz>::MAX);
+            hint_round_trip(&<$nz>::MIN);
+            hint_round_trip(&<$nz>::new(1 as $base).unwrap());
+            hint_round_trip(&<$nz>::new(2 as $base).unwrap());
+            hint_round_trip(&<$nz>::MAX);
         };
     }
 
@@ -166,11 +168,11 @@ mod tests {
 
     macro_rules! round_trip_opt {
         ($nz:ty, $base:ty) => {
-            crate::__test::round_trip(Some(<$nz>::MIN));
-            crate::__test::round_trip(Option::<$nz>::None);
-            crate::__test::round_trip(Some(<$nz>::new(1 as $base).unwrap()));
-            crate::__test::round_trip(Some(<$nz>::new(2 as $base).unwrap()));
-            crate::__test::round_trip(Some(<$nz>::MAX));
+            hint_round_trip(&Some(<$nz>::MIN));
+            hint_round_trip(&Option::<$nz>::None);
+            hint_round_trip(&Some(<$nz>::new(1 as $base).unwrap()));
+            hint_round_trip(&Some(<$nz>::new(2 as $base).unwrap()));
+            hint_round_trip(&Some(<$nz>::MAX));
         };
     }
 

--- a/src/prim/num.rs
+++ b/src/prim/num.rs
@@ -49,13 +49,15 @@ impl_for!(f64);
 
 #[cfg(test)]
 mod tests {
+    use crate::test::*;
+
     macro_rules! round_trip {
         ($ty:ty) => {
-            crate::__test::round_trip(<$ty>::MIN);
-            crate::__test::round_trip(0 as $ty);
-            crate::__test::round_trip(1 as $ty);
-            crate::__test::round_trip(2 as $ty);
-            crate::__test::round_trip(<$ty>::MAX);
+            hint_round_trip(&<$ty>::MIN);
+            hint_round_trip(&(0 as $ty));
+            hint_round_trip(&(1 as $ty));
+            hint_round_trip(&(2 as $ty));
+            hint_round_trip(&<$ty>::MAX);
         };
     }
 
@@ -72,9 +74,10 @@ mod tests {
         round_trip!(u64);
         round_trip!(i64);
         #[cfg(feature = "i128")]
-        round_trip!(u128);
-        #[cfg(feature = "i128")]
-        round_trip!(i128);
+        {
+            round_trip!(u128);
+            round_trip!(i128);
+        }
 
         round_trip!(f32);
         round_trip!(f64);

--- a/src/prim/unit.rs
+++ b/src/prim/unit.rs
@@ -26,8 +26,10 @@ impl Encode for () {
 
 #[cfg(test)]
 mod tests {
+    use crate::test::*;
+
     #[test]
     fn round_trip() {
-        crate::__test::round_trip(());
+        hint_round_trip(&());
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,63 @@
+#![allow(clippy::missing_panics_doc)]
+
+//! Utilities for testing trait implementations.
+//!
+//! Use these functions when writing unit tests for your [`Encode`] and
+//! [`Decode`] implementations.
+
+use core::fmt::Debug;
+
+use crate::{Buf, BytesMut, Decode, Encode, EncodeLen, FixedEncodeLenHint, Read, Write};
+
+/// Asserts that `T`'s [`EncodeLen::encode_len`] is within the bounds of
+/// [`FixedEncodeLenHint`].
+pub fn encode_len_hint<T: FixedEncodeLenHint>(value: &T) {
+    let encode_len = value.encode_len();
+    assert!(
+        encode_len >= T::MIN_ENCODE_LEN,
+        "encode_len = {encode_len}, T::MIN_ENCODE_LEN: {}",
+        T::MIN_ENCODE_LEN
+    );
+    assert!(
+        encode_len <= T::MAX_ENCODE_LEN,
+        "encode_len = {encode_len}, T::MAX_ENCODE_LEN: {}",
+        T::MAX_ENCODE_LEN
+    );
+}
+
+/// Asserts that `decode(encode(value)) == value`.
+pub fn round_trip<T>(value: &T)
+where
+    T: Debug + Encode + Decode + EncodeLen + PartialEq,
+    <T as Encode>::Error: Debug,
+    <T as Decode>::Error: Debug,
+{
+    let encode_len = value.encode_len();
+
+    let mut buf = BytesMut::with_capacity(encode_len);
+    buf.write(&value).unwrap();
+    assert_eq!(encode_len, buf.len());
+
+    let mut buf = buf.freeze();
+    assert_eq!(encode_len, buf.remaining());
+
+    let buf_clone = buf.clone();
+    let actual = buf.read::<T>().unwrap();
+    assert!(
+        *value == actual,
+        "expected = {value:?}, actual = {actual:?}, buf: {:?}",
+        buf_clone.chunk()
+    );
+    assert_eq!(0, buf.remaining());
+}
+
+/// Asserts [`encode_len_hint`] and [`round_trip`] for `T`.
+pub fn hint_round_trip<T>(value: &T)
+where
+    T: Debug + Encode + Decode + EncodeLen + FixedEncodeLenHint + PartialEq,
+    <T as Encode>::Error: Debug,
+    <T as Decode>::Error: Debug,
+{
+    encode_len_hint(value);
+    round_trip(value);
+}

--- a/src/varint/mod.rs
+++ b/src/varint/mod.rs
@@ -164,31 +164,33 @@ mod tests {
 
     use super::*;
 
+    use crate::test::*;
+
     #[test]
     fn round_trip_all_u8s() {
         for v in 0..u8::MAX {
-            crate::__test::round_trip(VarInt(v));
+            hint_round_trip(&VarInt(v));
         }
     }
 
     #[test]
     fn round_trip_all_i8s() {
         for v in 0..i8::MAX {
-            crate::__test::round_trip(VarInt(v));
+            hint_round_trip(&VarInt(v));
         }
     }
 
     #[test]
     fn round_trip_all_u16s() {
         for v in 0..u16::MAX {
-            crate::__test::round_trip(VarInt(v));
+            hint_round_trip(&VarInt(v));
         }
     }
 
     #[test]
     fn round_trip_all_i16s() {
         for v in 0..i16::MAX {
-            crate::__test::round_trip(VarInt(v));
+            hint_round_trip(&VarInt(v));
         }
     }
 


### PR DESCRIPTION
Exposes `octs::test` for users writing their own Encode and Decode impls, so they can unit test their impls.